### PR TITLE
execute_batch() deve ser chamado independente da situação do sendBeacon

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -282,7 +282,7 @@ var uid = aidax_visitor_id,
           "] \n" +
           JSON.stringify(properties)
       );
-      if (navigator.sendBeacon && ready) {
+      if (ready) {
         execute_batch();
       }
     }


### PR DESCRIPTION
A função execute_batch() já verifica e trata a situação em que a função sendBeacon() está indisponível (retorna false), realizando um XMLHttpRequest (linha 379) para envio dos dados.
Ao verificar e impedir a chamada da função na linha 285 os dados não serão enviados, mesmo com uma maneira alternativa disponível.

Isso pode se tornar um problema se a página fizer um número de requisições superior ao limite dado pelo navegador.