### PR TITLE
Fixed event ID regex

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -212,6 +212,10 @@ var AIDAX_COLLECTOR = "//api.aidax.com.br",
     var uuid_regex = /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
     return uuid_regex.test(id);
   },
+  validate_eventid = function(event_id){
+    var eid_regex = /^[0-9A-F]{8}-[0-9A-F]{4}-5[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;
+    return eid_regex.test(event_id);
+  },
   href = getHref(),
   referer = getReferrer(),
   device = UAParser(),
@@ -407,7 +411,7 @@ var uid = aidax_visitor_id,
       );
       var cond2 = assert(
         typeof obj.id === "undefined" ||
-          (typeof obj.id === "string" && validate_uuid(obj.id)),
+          (typeof obj.id === "string" && validate_eventid(obj.id)),
         "[AIDAX] Invalid event ID."
       );
       if(cond1 && cond2) {


### PR DESCRIPTION
Passing a valid event ID always returns "Invalid event ID" due to incorrect verification, making impossible to update events.
While most uuid expects the 15th character to be a "4", a valid event ID contains the constant "5" on the 15th position, making the validate_uuid function unable to correctly validade an event's ID.